### PR TITLE
Core_raw_data

### DIFF
--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -344,7 +344,7 @@ if button_pressed:
 
 
 with container_raw_data:
-    st.dataframe(df_raw_od_data, use_container_width=False)
+    st.dataframe(df_raw_od_data, width="content")
 
 if df_wide_raw_od_data is not None and masked is not None:
     # Download options


### PR DESCRIPTION
- essentially only a timestamp column, the reactor unit and the OD measurement

Aside: In labels new line characters need to have two whitespaces in front `  \n`