### PR TITLE
Refactor iqr

### DIFF
--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 
+import growthcurves as gc
 import pandas as pd
 import streamlit as st
 from buttons import download_data_button_in_sidebar
@@ -412,14 +413,17 @@ if button_pressed:
 
     if filter_by_iqr_range:
         mask_outliers = (
-            df_wide_raw_od_data_filtered.rolling(
-                rolling_window,
-                min_periods=min_periods,
-                center=True,
-                closed="both",
-            )
-            .apply(piogrowth.filter.out_of_iqr, kwargs={"factor": iqr_range_value})
-            .astype(bool)
+            df_wide_raw_od_data_filtered
+            # .rolling(     rolling_window,
+            #     min_periods=min_periods,
+            #     center=True,
+            #     closed="both",
+            # )
+            .apply(
+                gc.preprocessing.out_of_iqr,
+                raw=False,
+                **{"factor": iqr_range_value, "window_size": rolling_window},
+            ).astype(bool)
         )
         # st.write(f"### Number of outliers detected: {mask_outliers.sum().sum()}")
         msg += f"- Number of outliers detected: {mask_outliers.sum().sum()}\n"

--- a/src/piogrowth/filter.py
+++ b/src/piogrowth/filter.py
@@ -28,9 +28,9 @@ if __name__ == "__main__":
     # does not work on series due to indexing using values.
     mask = data.rolling(window=5, center=True).apply(
         lambda s: out_of_iqr_window(
-            s.values,
+            s,
         ),
-        raw=False,
+        raw=True,
     )
     print(mask)
 
@@ -41,4 +41,8 @@ if __name__ == "__main__":
 
     # series is understood by numpy and values are accessed.
     mask = gc_out_of_iqr(data, window_size=5)
+    print(mask)
+
+    mask = data.to_frame("S1").apply(gc_out_of_iqr, args=(5,))
+
     print(mask)

--- a/src/piogrowth/filter.py
+++ b/src/piogrowth/filter.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+from growthcurves.preprocessing import out_of_iqr as gc_out_of_iqr
+from growthcurves.preprocessing import out_of_iqr_window
 
 
 def out_of_iqr(s: pd.Series, factor: float = 1.5) -> pd.Series:
@@ -16,3 +18,27 @@ def out_of_iqr(s: pd.Series, factor: float = 1.5) -> pd.Series:
     # center point out of IQR?
 
     return (center < lower_bound) | (center > upper_bound)
+
+
+if __name__ == "__main__":
+    data = pd.Series([20, 1, 2, 3, 4, 5, 20, 6, 7, 8, 9, 10, 20])
+    mask = data.rolling(window=5, center=True).apply(out_of_iqr, raw=False)
+    print(mask)
+
+    # does not work on series due to indexing using values.
+    mask = data.rolling(window=5, center=True).apply(
+        lambda s: out_of_iqr_window(
+            s.values,
+        ),
+        raw=False,
+    )
+    print(mask)
+
+    # would exclude the first and last 2 points as they are NaN, but we want to label
+    # them as outliers if they are out of IQR in their respective windows
+    mask = mask.astype(bool)
+    print(mask)
+
+    # series is understood by numpy and values are accessed.
+    mask = gc_out_of_iqr(data, window_size=5)
+    print(mask)


### PR DESCRIPTION
This pull request updates the outlier detection logic in the data upload pipeline to use the `growthcurves` library's `out_of_iqr` function, and includes related code improvements and testing. The main focus is on improving and standardizing outlier filtering by leveraging external, well-tested functionality.

**Integration of external outlier detection and related updates:**

* Updated the outlier filtering in `app/0_upload_data.py` to use `gc.preprocessing.out_of_iqr` from the `growthcurves` library, replacing the previous custom rolling window approach. This change also passes additional parameters such as `window_size` and `factor` for more flexible filtering. [[1]](diffhunk://#diff-e8ad4ec81ce3a6ff06b59202ef76b2e50b724fc4479a786377720cf5dc90c827R3) [[2]](diffhunk://#diff-e8ad4ec81ce3a6ff06b59202ef76b2e50b724fc4479a786377720cf5dc90c827L415-R426)
* Imported `out_of_iqr` and `out_of_iqr_window` from `growthcurves.preprocessing` in `src/piogrowth/filter.py`, and aliased `out_of_iqr` as `gc_out_of_iqr` for clarity.

**Testing and demonstration code:**

* Added a `__main__` block to `src/piogrowth/filter.py` with example usages and print statements to demonstrate and test the outlier detection logic, including both local and `growthcurves` implementations.

Depends on changes in growthcurves
https://github.com/biosustain/growthcurves/pull/42