### PR TITLE
Apply feedback (part 1)

### DIFF
--- a/app/0_data_dashboard.py
+++ b/app/0_data_dashboard.py
@@ -83,6 +83,7 @@ if df_wide_raw_od_data is not None and masked is not None:
             df_plot,
             mask_plot,
             sharey=use_same_yaxis_scale,
+            sharex=False,
             is_data_index=not use_elapsed_time,
         )
         st.write(fig)

--- a/app/0_data_dashboard.py
+++ b/app/0_data_dashboard.py
@@ -87,11 +87,13 @@ if df_wide_raw_od_data is not None and masked is not None:
         )
         st.write(fig)
 
+# show summary message about data processing
 if processing_summary:
     with st.container(border=True):
         st.subheader("Processing summary of OD readings")
         st.markdown(processing_summary)
 
+# show rolling median table
 if df_rolling is not None:
     with st.container(border=True):
         st.header("Rolling Median")
@@ -103,6 +105,7 @@ if df_rolling is not None:
             st.subheader("Rolling median using filtered OD data")
         st.write(df_rolling)
 
+        # consider removing this plot
         if not use_elapsed_time and start_time is not None:
             view = df_rolling.copy()
             view.index = start_time + pd.to_timedelta(view.index, unit="h")
@@ -112,6 +115,7 @@ if df_rolling is not None:
         ax = view.plot.line(style=".", ms=2)
         st.write(ax.get_figure())
 
+# Download buttons in sidebar
 if st.session_state.get("df_raw_od_data") is not None:
     download_data_button_in_sidebar(
         "df_raw_od_data",

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -606,7 +606,6 @@ if button_pressed:
             "removed globally."
         )
     #### switch wide data to time eplased in hours #####################################
-    st.session_state["start_time"] = df_wide_raw_od_data_filtered.index[0]
     df_rolling = piogrowth.reindex_w_relative_time(
         df=df_rolling,
         start_time=st.session_state["start_time"],

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -483,9 +483,12 @@ if button_pressed:
         _min_date, _max_date = time_range
         _min_date = max(_min_date, min_date)
         _max_date = min(_max_date, max_date)
-        df_wide_raw_od_data[reactor] = df_wide_raw_od_data.loc[
-            _min_date:_max_date, reactor
-        ]
+        reactor_in_window = df_wide_raw_od_data.index.to_series().between(
+            _min_date, _max_date
+        )
+        df_wide_raw_od_data.loc[:, reactor] = df_wide_raw_od_data[reactor].where(
+            reactor_in_window
+        )
 
         if update_zero_timepoint and start_time < _min_date:
             # update start time if new zero time is after current start time

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -40,8 +40,9 @@ def callback_clear_raw_data():
 
 
 ########################################################################################
-# Upload File section
+# Step 1: Upload File with OD/bioscatter data
 with st.container(border=True):
+    # header and example data file with requirements in popover
     header_col, req_col = st.columns([4, 1], vertical_alignment="center")
     with header_col:
         st.header("Step 1. Upload PioReactor OD Data")
@@ -53,12 +54,13 @@ with st.container(border=True):
                 "- Required columns: `timestamp_localtime`, `pioreactor_unit`, `od_reading`"
             )
             st.markdown("- One row per measurement")
+            st.markdown("\n > Export from PioReactor WebApp or CLI.")
             st.divider()
             st.markdown("**Example file:**")
             example_data = pd.read_csv("data/example_batch_data_od_readings.csv")
             st.dataframe(example_data.head(10), hide_index=True, width="stretch")
             st.download_button(
-                label="Download example CSV",
+                label="Download example CSV for App testing",
                 data=example_data.to_csv(index=False),
                 file_name="example_batch_data_od_readings.csv",
                 key="download_example_csv",
@@ -66,7 +68,7 @@ with st.container(border=True):
                 type="primary",
                 width="stretch",
             )
-
+    # File Uploading of main data file
     st.markdown("**Main OD Data**")
     file = st.file_uploader(
         "PioReactor OD table. Upload a single CSV file with PioReactor recordings.",
@@ -92,11 +94,35 @@ with st.container(border=True):
             st.warning("No data uploaded.")
             st.info("Upload a comma-separated (`.csv`) file to get started.")
 
+# Step 2: Optional metadata uploads
 with st.container(border=True):
-    st.header("Step 2. Optional metadata uploads")
+    header_col, req_col = st.columns([4, 1], vertical_alignment="center")
+    header_col.header("Step 2. Optional metadata uploads")
+
+    # show both optional uploads
     optional_upload_cols = st.columns([2, 3], gap="small")
     with optional_upload_cols[0]:
         st.markdown("**OD Calibration Table**")
+        with st.popover("See an Example", width="stretch"):
+            st.markdown("**OD Calibration Table**")
+            st.markdown(
+                "- CSV file with columns `reactor` and `od`.\n"
+                "- Used to adjust OD readings by reactor based on calibration data."
+            )
+            st.divider()
+            st.markdown("**Example:**")
+            fname = "data/example_batch_data_od_readings_calibration.csv"
+            example_data = pd.read_csv(fname)
+            st.dataframe(example_data, hide_index=True, width="stretch")
+            st.download_button(
+                label="Download example calibration CSV.",
+                data=example_data.to_csv(index=False),
+                file_name="example_batch_data_od_readings_calibration.csv",
+                key="download_example_csv_calibration",
+                mime="text/csv",
+                type="primary",
+                width="stretch",
+            )
         od_adjustment_upload = st.file_uploader(
             "OD adjustment table",
             type=["csv", "txt"],
@@ -104,6 +130,37 @@ with st.container(border=True):
         )
     with optional_upload_cols[1]:
         st.markdown("**Turbidostat Metadata**")
+        with st.popover("See an Example", width="stretch"):
+            st.markdown("**Turbidostat Metadata**")
+            st.markdown(
+                """
+                If provided, peaks are not autodetected.
+                
+                - CSV file with columns `timestamp_localtime`, `pioreactor_unit`,
+                `event_name` and `message` and `data`.
+
+                - Used to parse `DilutionEvents` for turbidostat analysis 
+                  based on event descriptions in the metadata. 
+                  If not provided, peaks will be autodetected based on OD data.
+                """
+            )
+
+            st.markdown("\n > Export from PioReactor WebApp or CLI.")
+            st.divider()
+            st.markdown("**Example:**")
+            fname = "data/example_2-Pio_Experiment_dilution_events.csv"
+            example_data = pd.read_csv(fname)
+            st.dataframe(example_data, hide_index=True, width="stretch")
+            st.download_button(
+                label="Download example dilution events CSV.",
+                data=example_data.to_csv(index=False),
+                file_name="example_2-Pio_Experiment_dilution_events.csv",
+                key="download_example_csv_dilution",
+                mime="text/csv",
+                type="primary",
+                width="stretch",
+            )
+
         turbidostat_meta_upload = st.file_uploader(
             "Dilution metadata (for Turbidostat page)",
             type=["csv"],

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -234,18 +234,19 @@ with st.container(border=True):
             )
         filter_columns = st.columns(2)
         with filter_columns[0]:
+            negative_options = [
+                "Set negative OD readings to missing (NaN)",
+                "Impute negative values by moving average",
+            ]
+            default_negative = st.session_state.get("negative_handling", negative_options[0])
+            try:
+                default_negative_index = negative_options.index(default_negative)
+            except ValueError:
+                default_negative_index = 0
             negative_handling = st.radio(
                 "How should negative OD readings be handled?",
-                options=[
-                    "Set negative OD readings to missing (NaN)",
-                    "Impute negative values by moving average",
-                ],
-                index=(
-                    1
-                    # if st.session_state.get("remove_negative", False)
-                    # and st.session_state.get("fill_na", False)
-                    # else 0
-                ),
+                options=negative_options,
+                index=default_negative_index,
                 key="negative_handling",
                 help=(
                     "Negative values distort curve fitting. Choose whether to convert "

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -99,7 +99,7 @@ with st.container(border=True):
         st.markdown("**OD Calibration Table**")
         od_adjustment_upload = st.file_uploader(
             "OD adjustment table",
-            type=["csv"],
+            type=["csv", "txt"],
             key="upload_page_od_adjustment_table",
         )
     with optional_upload_cols[1]:

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -177,14 +177,27 @@ with st.container(border=True):
             )
         filter_columns = st.columns(2)
         with filter_columns[0]:
-            remove_negative = st.checkbox(
-                "Set negative OD readings to missing (NaN)",
-                help=(
-                    "Negative values will distort the curve fitting as the logarithm is "
-                    "set to NaN."
+            negative_handling = st.radio(
+                "How should negative OD readings be handled?",
+                options=[
+                    "Set negative OD readings to missing (NaN)",
+                    "Impute negative values by moving average",
+                ],
+                index=(
+                    1
+                    # if st.session_state.get("remove_negative", False)
+                    # and st.session_state.get("fill_na", False)
+                    # else 0
                 ),
-                value=st.session_state.get("remove_negative", False),
+                key="negative_handling",
+                help=(
+                    "Negative values distort curve fitting. Choose whether to convert "
+                    "them to missing values or impute them."
+                ),
             )
+            remove_negative = True
+            if negative_handling == "Impute negative values by moving average":
+                remove_negative = False
             fill_na = st.checkbox(
                 "Impute missing bioscatter readings using forward and backward filling",
                 help=(
@@ -500,6 +513,24 @@ if button_pressed:
         msg += f"   - in detail: {mask_negative.sum().to_dict()}\n"
         df_wide_raw_od_data_filtered = df_wide_raw_od_data_filtered.mask(mask_negative)
         masked = masked | mask_negative
+    else:
+        mask_negative = df_wide_raw_od_data_filtered < 0
+        window = 31
+        # Replace negatives with NaN,
+        # then compute centered rolling mean over non-missing values
+        temp = df_wide_raw_od_data_filtered.mask(mask_negative)
+        rolling_mean = temp.rolling(window=window, min_periods=1, center=True).mean()
+        df_wide_raw_od_data_filtered = df_wide_raw_od_data_filtered.mask(
+            mask_negative, rolling_mean
+        )
+        n_imputed = mask_negative.sum().sum()
+        msg += (
+            f"- Imputed {n_imputed:,d} negative OD readings using"
+            f" centered rolling mean (window={window}).\n"
+        )
+        msg += f"   - in detail: {mask_negative.sum().to_dict()}\n"
+        masked = masked | mask_negative
+        del temp, rolling_mean, mask_negative
     if fill_na:
         mask_na = df_wide_raw_od_data_filtered.isna()
         msg += f"- Filling {mask_na.sum().sum():,d} missing OD readings.\n"

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -475,6 +475,7 @@ if button_pressed:
         st.info(f"Time range: {min_date} to {max_date}")
 
     if update_zero_timepoint:
+        print(f"Updating zero timepoint to {min_date} based on user selection.")
         start_time = min_date
 
     for reactor, time_range in time_ranges.items():
@@ -632,3 +633,30 @@ if button_pressed:
     st.session_state["upload_processing_summary_msg"] = msg
     st.write("### Data processing summary:")
     st.write(msg)
+
+
+# Debug option to inspect session state variables related to data upload and processing
+if st.session_state.get("debug_mode", False):
+    with st.expander("Developer inspect (session state)", expanded=False):
+        st.write("Session state variables related to data upload and processing:")
+        st.write(
+            {
+                "custom_id": st.session_state.get("custom_id"),
+                "keep_core_data": st.session_state.get("keep_core_data"),
+                "reactors_selected": st.session_state.get("reactors_selected"),
+                "remove_negative": st.session_state.get("remove_negative"),
+                "fill_na": st.session_state.get("fill_na"),
+                "remove_downward_trending": st.session_state.get(
+                    "remove_downward_trending"
+                ),
+                "remove_max": st.session_state.get("remove_max"),
+                "filter_by_iqr_range": st.session_state.get("filter_by_iqr_range"),
+                "quantile_max": st.session_state.get("quantile_max"),
+                "iqr_range_value": st.session_state.get("iqr_range_value"),
+                "rolling_window": st.session_state.get("rolling_window"),
+                "round_time": st.session_state.get("round_time"),
+                "time_ranges": st.session_state.get("time_ranges"),
+                "update_zero_timepoint": st.session_state.get("update_zero_timepoint"),
+                "start_time (session.state)": st.session_state.get("start_time"),
+            }
+        )

--- a/app/0_upload_data.py
+++ b/app/0_upload_data.py
@@ -205,9 +205,13 @@ with st.container(border=True):
         st.session_state["turbidostat_meta_upload_bytes"] = None
         st.session_state["turbidostat_meta_upload_name"] = None
 
+# Step 3: Configure preprocessing options
 ### Form ##############################################################################
 with st.container(border=True):
     st.header("Step 3. Configure Processing Options")
+    st.warning(
+        'Options are only saved if you press "Apply options to uploaded data" button at the end of this section.'
+    )
 
     with st.form("Upload_data_form", clear_on_submit=False):
         st.write("#### Data filtering options:")
@@ -238,16 +242,17 @@ with st.container(border=True):
                 "Set negative OD readings to missing (NaN)",
                 "Impute negative values by moving average",
             ]
-            default_negative = st.session_state.get("negative_handling", negative_options[0])
+            default_negative = st.session_state.get(
+                "negative_handling", negative_options[1]
+            )
             try:
                 default_negative_index = negative_options.index(default_negative)
             except ValueError:
-                default_negative_index = 0
+                default_negative_index = 1
             negative_handling = st.radio(
                 "How should negative OD readings be handled?",
                 options=negative_options,
                 index=default_negative_index,
-                key="negative_handling",
                 help=(
                     "Negative values distort curve fitting. Choose whether to convert "
                     "them to missing values or impute them."
@@ -398,6 +403,7 @@ st.session_state["keep_core_data"] = keep_core_data
 st.session_state["custom_id"] = custom_id
 st.session_state["reactors_selected"] = reactors_selected
 st.session_state["remove_negative"] = remove_negative
+st.session_state["negative_handling"] = negative_handling
 st.session_state["fill_na"] = fill_na
 st.session_state["remove_downward_trending"] = remove_downward_trending
 st.session_state["remove_max"] = remove_max

--- a/app/1_batch_analysis.py
+++ b/app/1_batch_analysis.py
@@ -408,7 +408,7 @@ Workflow:
 BATCH_HELP = f"{BATCH_HELP}\n\n---\n\n{piogrowth.analyze.load_method_notes_markdown()}"
 
 
-page_header_with_help("Batch Growth Analysis", BATCH_HELP)
+page_header_with_help("Analyze growth experiment in batch mode", BATCH_HELP)
 
 if no_data_uploaded:
     show_warning_to_upload_data()

--- a/app/1_batch_analysis.py
+++ b/app/1_batch_analysis.py
@@ -1018,6 +1018,8 @@ with st.container(border=True):
             type="primary",
             width="stretch",
         )
+
+# Debug option to inspect session state variables related to batch analysis
 if st.session_state.get("debug_mode", False):
     with st.expander("Developer inspect (session state)", expanded=False):
         st.write("Used parameters map for re-analysis selection:")

--- a/app/2_turbiostat.py
+++ b/app/2_turbiostat.py
@@ -385,6 +385,20 @@ for ax, col in zip(axes, df_rolling.columns):
         ax.axvspan(_start, _end, color="gray", alpha=0.2)
 with st.container(border=True):
     st.subheader("Step 4. Review Fitted Curves and Peaks")
+    st.markdown(
+        """
+        - <span style="color:#1f77b4;"><b>Blue points</b></span>: OD data used for
+                analysis (after optional removal of downward trending points)</li>
+        - <span style="color:#7f7f7f;"><b>Grey dashed lines</b></span>: Detected
+        peaks indicating potential dilution events, either from uploaded metadata
+        or automatic detection</li>
+        - <span style="color:#d62728;"><b>Red dashed lines</b></span>: Maximum
+        growth timepoint for turbiostat window</li>
+        - <span style="color:#9e9e9e;"><b>Gray shaded areas</b></span>: Exponential
+        growth phases as determined by fitted model</li>
+        """,
+        unsafe_allow_html=True,
+    )
     st.pyplot(fig)
 
 with st.sidebar:

--- a/app/2_turbiostat.py
+++ b/app/2_turbiostat.py
@@ -356,33 +356,35 @@ xlabel = DEFAULT_XLABEL_REL
 # ? should the one with negative values removed stored globally?
 st.session_state["df_rolling_turbidostat"] = df_rolling
 
-stats_df = _run_model_fitting_on_df_with_peaks_compat(
-    df_rolling,
-    peaks,
-    model_name=selected_model,
-    n_fits=fits_sliding_window,
-    spline_s=spline_smoothing_value,
-    smooth_mode=smooth_mode,
-    window_points=window_points,
-    phase_boundary_method=phase_boundary_method,
-    exp_threshold=exp_cutoff,
-    lag_threshold=lag_cutoff,
-)
+with st.spinner(text="Fitting curves...", show_time=True):
+    stats_df = _run_model_fitting_on_df_with_peaks_compat(
+        df_rolling,
+        peaks,
+        model_name=selected_model,
+        n_fits=fits_sliding_window,
+        spline_s=spline_smoothing_value,
+        smooth_mode=smooth_mode,
+        window_points=window_points,
+        phase_boundary_method=phase_boundary_method,
+        exp_threshold=exp_cutoff,
+        lag_threshold=lag_cutoff,
+    )
 
-fig, axes = plot_growth_data_w_peaks(df_rolling, peaks, is_data_index=False)
+    fig, axes = plot_growth_data_w_peaks(df_rolling, peaks, is_data_index=False)
 
-time_at_mu_max = stats_df["time_at_umax"]
+    time_at_mu_max = stats_df["time_at_umax"]
 
-axes = axes.flatten()
-for ax, _col in zip(axes, df_rolling.columns):
-    s_maxima = time_at_mu_max.loc[_col]
-    for x in s_maxima:
-        ax.axvline(x=x, color="red", linestyle="--")
-for ax, col in zip(axes, df_rolling.columns):
-    sub_df = stats_df.loc[col]
-    range_exp_phase = list(zip(sub_df["exp_phase_start"], sub_df["exp_phase_end"]))
-    for _start, _end in range_exp_phase:
-        ax.axvspan(_start, _end, color="gray", alpha=0.2)
+    axes = axes.flatten()
+    for ax, _col in zip(axes, df_rolling.columns):
+        s_maxima = time_at_mu_max.loc[_col]
+        for x in s_maxima:
+            ax.axvline(x=x, color="red", linestyle="--")
+    for ax, col in zip(axes, df_rolling.columns):
+        sub_df = stats_df.loc[col]
+        range_exp_phase = list(zip(sub_df["exp_phase_start"], sub_df["exp_phase_end"]))
+        for _start, _end in range_exp_phase:
+            ax.axvspan(_start, _end, color="gray", alpha=0.2)
+
 with st.container(border=True):
     st.subheader("Step 4. Review Fitted Curves and Peaks")
     st.markdown(

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,12 @@ logo_source = (
 )
 
 # General configurations
-st.set_page_config(page_title="PioGrowth", layout="wide", page_icon=logo_source)
+st.set_page_config(
+    page_title="PioGrowth",
+    layout="wide",
+    page_icon=logo_source,
+    initial_sidebar_state="expanded",
+)
 
 st.logo(logo_source, link="https://github.com/biosustain/PioGrowth")
 

--- a/app/plots.py
+++ b/app/plots.py
@@ -20,6 +20,7 @@ def plot_growth_data_w_mask(
     df_wide: pd.DataFrame,
     df_mask: pd.DataFrame,
     sharey: bool = False,
+    sharex: bool = True,
     is_data_index: bool = True,
 ) -> plt.Figure:
     """Plot optical density (OD) growth data."""
@@ -27,7 +28,7 @@ def plot_growth_data_w_mask(
 
     units = df_wide.shape[1]
     fig, axes = plt.subplots(
-        units, 1, figsize=(10, 2 * units), sharey=sharey, sharex=True, squeeze=False
+        units, 1, figsize=(10, 2 * units), sharey=sharey, sharex=sharex, squeeze=False
     )
     axes = axes.flatten()
     df_columns = df_wide.columns

--- a/app/plots.py
+++ b/app/plots.py
@@ -60,13 +60,13 @@ def plot_growth_data_w_mask(
             s=2,
             title=f"Reactor: {col}",  # Customize legend text here
         )
-    ax = axes[-1]
-    fig = ax.get_figure()
     fig.tight_layout()
 
     if is_data_index:
         date_form = DateFormatter("%Y-%m-%d %H:%M")
-        _ = ax.xaxis.set_major_formatter(date_form)
+        for ax in axes:
+            ax.xaxis.set_major_formatter(date_form)
+
     return fig
 
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,6 @@
 *.csv
+*.html
+*.xlsx
+
+querve_files/
+stijn_kral/

--- a/data/example_batch_data_od_readings_calibration.csv
+++ b/data/example_batch_data_od_readings_calibration.csv
@@ -1,0 +1,13 @@
+reactor,od
+Auto-P01,0.03
+Auto-P01,4.2
+Auto-P02,0.03
+Auto-P02,4.2
+Auto-P04,0.03
+Auto-P04,4.2
+Auto-P05,0.3
+Auto-P05,4.2
+Auto-P06,0.03
+Auto-P06,4.2
+Auto-P08,0.03
+Auto-P08,4.2

--- a/src/piogrowth/__init__.py
+++ b/src/piogrowth/__init__.py
@@ -1,10 +1,13 @@
 # The __init__.py file is loaded when the package is loaded.
 # It is used to indicate that the directory in which it resides is a Python package
+import logging
 from importlib import metadata
 
 import pandas as pd
 
 from . import filter, load
+
+logger = logging.getLogger(__name__)
 
 __version__ = metadata.version("piogrowth")
 
@@ -20,7 +23,10 @@ def reindex_w_relative_time(
 ) -> pd.DataFrame:
     """Reindex the DataFrame to use relative time as the index."""
     df = df.copy()  # needed as reindex as DataFrame is a view
-    df.index = convert_to_elapsed_hours(df.index, start_time=start_time or df.index[0])
+    if start_time is None:
+        logger.debug("Start time is None, using minimum timestamp.")
+        start_time = df.index.min()
+    df.index = convert_to_elapsed_hours(df.index, start_time=start_time)
     df.index.name = new_index_name
     return df
 


### PR DESCRIPTION
- sidebar shown per default
- impute negative values option (with moving average of non-missing values)
- fix: do not always readjust zero timepoint
- debug option on upload page to inspect state
- calibration: allow `txt` (needs additional changes)
- describe all file formats on upload page
- turbiostat: show what is shown in the figure